### PR TITLE
Fixes for XFCE

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,5 +1,6 @@
 mod kde;
 mod lxde;
+mod xfce;
 
 #[cfg(feature = "from_url")]
 use crate::download_image;
@@ -30,15 +31,7 @@ pub fn get() -> Result<String, Box<dyn std::error::Error>> {
             "dconf",
             &["read", "/org/mate/desktop/background/picture-filename"],
         ),
-        "XFCE" => get_stdout(
-            "xfconf-query",
-            &[
-                "-c",
-                "xfce4-desktop",
-                "-p",
-                "/backdrop/screen0/monitor0/workspace0/last-image",
-            ],
-        ),
+        "XFCE" => xfce::get(),
         "LXDE" => lxde::get(),
         "Deepin" => parse_dconf(
             "dconf",
@@ -81,17 +74,7 @@ pub fn set_from_path(path: &str) -> Result<(), Box<dyn std::error::Error>> {
                 &enquote::enquote('"', &path),
             ],
         ),
-        "XFCE" => run(
-            "xfconf-query",
-            &[
-                "-c",
-                "xfce4-desktop",
-                "-p",
-                "/backdrop/screen0/monitor0/workspace0/last-image",
-                "-s",
-                &path,
-            ],
-        ),
+        "XFCE" => xfce::set(path),
         "LXDE" => run("pcmanfm", &["-w", &path]),
         "Deepin" => run(
             "dconf",

--- a/src/linux/xfce.rs
+++ b/src/linux/xfce.rs
@@ -1,0 +1,41 @@
+use crate::get_stdout;
+use crate::run;
+use Result;
+
+/// Returns the wallpaper of XFCE.
+pub fn get() -> Result<String, Box<dyn std::error::Error>> {
+    let mut ret = String::new();
+    for xfce_path in get_last_image_paths()? {
+        ret = format!(
+            "{},{}",
+            ret,
+            get_stdout("xfconf-query", &["-c", "xfce4-desktop", "-p", &xfce_path])?
+        )
+    }
+    Ok(ret)
+}
+
+/// Sets the wallpaper for XFCE.
+pub fn set(path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    for xfce_path in get_last_image_paths()? {
+        run(
+            "xfconf-query",
+            &["-c", "xfce4-desktop", "-p", &xfce_path, "-s", &path],
+        )?
+    }
+    Ok(())
+}
+
+fn get_last_image_paths() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let str = get_stdout("xfconf-query", &["-l", "-c", "xfce4-desktop"])?;
+    Ok(str
+        .split("\n")
+        .filter(|s| s.ends_with("/last-image"))
+        .map(|s| s.to_string())
+        .collect::<Vec<String>>())
+}
+
+#[test]
+fn test_get_wallpaper() {
+    dbg!(crate::linux::xfce::get().unwrap());
+}


### PR DESCRIPTION
The previous implementation only updated `/backdrop/screen0/monitor0/workspace0/last-image`, which didn't work for most of the XF CE configurations, as they've separated it into each monitor.
This could be improved further by adding support to setting only one screen/monitor at a time, but that would have to be supported for other backends as well.